### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# OctoAcme Project Management Docs
+
+This repository centralizes OctoAcme's project management processes, providing clear guidance for initiating, planning, executing, managing risks, deploying, and continuously improving projects. OctoAcme's approach emphasizes clear ownership, iterative delivery, empirical metrics, and transparent communication to ensure successful project outcomes. These processes apply to all cross-functional projects that deliver product features, services, or integrations, and are grounded in core principles: customer-first value delivery, iterative incremental releases, clearly defined roles and accountability, data-informed decision-making, and psychological safety for continuous learning.
+
+## Project Management Documents
+
+- **[Project Management Overview](./octoacme-project-management-overview.md)** — High-level introduction to OctoAcme's project approach, core roles (PM, PdM, Developers, QA), key artifacts, project lifecycle stages, and communication cadence.
+
+- **[Project Initiation Guide](./octoacme-project-initiation.md)** — Steps to validate and authorize new work, align stakeholders, and create a lightweight Project One-pager. Includes decision gates and initiation checklists.
+
+- **[Project Planning](./octoacme-project-planning.md)** — Process for turning approved initiatives into actionable plans and backlogs. Covers backlog creation, estimation, Definition of Done, dependencies, and release planning.
+
+- **[Execution & Tracking](./octoacme-execution-and-tracking.md)** — Day-to-day execution guidance including team rhythm (standups, syncs, demos), pull request workflows, quality and testing standards, metrics tracking, and blocker escalation.
+
+- **[Risk Management & Communication](./octoacme-risks-and-communication.md)** — How to identify, assess, monitor, and mitigate risks through a risk register. Includes stakeholder communication templates and escalation paths.
+
+- **[Release & Deployment Guide](./octoacme-release-and-deployment.md)** — Standardized release process covering release types, pre-release requirements, deployment checklists, rollback procedures, and release notes.
+
+- **[Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)** — How to capture learnings after sprints and releases, structure retrospectives, track action items, and build a culture of continuous improvement.
+
+- **[Roles and Personas](./octoacme-roles-and-personas.md)** — Definitions of typical roles (Developers, Product Managers, Project Managers) including responsibilities, goals, and communication patterns.
+
+---
+
+## Getting Started
+
+**New to OctoAcme projects?** Start with the [Project Management Overview](./octoacme-project-management-overview.md) for a concise introduction to our approach.
+
+**Launching a new project?** Follow the [Project Initiation Guide](./octoacme-project-initiation.md) to validate the idea and gain stakeholder alignment.
+
+**Planning or executing a project?** Use [Project Planning](./octoacme-project-planning.md) and [Execution & Tracking](./octoacme-execution-and-tracking.md) as your guides.
+
+**Need to manage risks or communicate status?** Refer to [Risk Management & Communication](./octoacme-risks-and-communication.md).
+
+**Ready to release?** Follow the [Release & Deployment Guide](./octoacme-release-and-deployment.md).
+
+**Wrapping up?** Run a retrospective using [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md) to capture learnings.
+
+---
+
+## Key Principles
+
+- **Customer-first**: Prioritize customer value and usability in all decisions.
+- **Iterative delivery**: Deliver small, testable increments rather than big-bang releases.
+- **Clear ownership**: Each project has a named Project Manager and Product Lead.
+- **Data-informed**: Measure impact and iterate based on evidence.
+- **Psychological safety**: Encourage feedback, learning, and blameless retrospectives.
+
+---
+
+## Questions?
+
+If you have questions about these processes or need clarification, reach out to the Project Management team or refer to the specific process document for more details.


### PR DESCRIPTION
Adds a central README summarizing processes and linking all doc files. Closes #2.